### PR TITLE
feat: 裁剪框角拖动逻辑补充

### DIFF
--- a/src/cropper.js
+++ b/src/cropper.js
@@ -400,6 +400,7 @@ export default {
     },
     setCutMode(type) {
       if(!this.src) return 
+      if(this.disableCtrl) return
       this.cutMode = true
       this.cutDirection = type
     },


### PR DESCRIPTION
解决有设置边界时,已设置不可改变裁剪框,但还是可以通过拖动裁剪框角将图片拖出范围